### PR TITLE
[기능 개선] 레벨마다 미로 크기가 조절되도록 수정 및 런타임 오류 해결

### DIFF
--- a/Player_move.cpp
+++ b/Player_move.cpp
@@ -3,14 +3,13 @@
 #include <conio.h> // _getch 함수를 사용하기 위함
 #include <vector>
 #include "Text.hpp"
-#include "fmod.hpp"
 #include "Player_move.hpp"
 #include "a_maze_map.hpp"
 using namespace std;
 
-extern const int N; // a_maze_map.cpp 에서 참조한 미로 크기 
-extern vector<vector<int>> maze; // a_maze_map.cpp 에서 참조한 미로 선언
-const int MAZE_SIZE = N; // 미로 크기
+extern int N; // a_maze_map.cpp 에서 참조한 미로 크기 
+extern vector<vector<int>> maze; // a_maze_map.cpp 에서 참조한 이차원 벡터 미로
+int MAZE_SIZE = N; // 미로 크기
 
 class Move { // 이동 함수를 담당하는 기본 클래스
 public:
@@ -121,8 +120,12 @@ public:
 int start_x, start_y; // 시작 위치 변수 저장용
 int end_x, end_y; // 도착점 위치 변수 저장용 
 
-// 스테이지 난이도 선택 후 본격적으로 게임 실행하는 함수
-void Playing() {
+// 스테이지 난이도 선택 후 본격적으로 게임 실행하는 함수, 미로 크기를 size 매개 변수로 받음.
+void Playing(int size) {
+	N = size; // 매개 변수 size 로 미로 크기 정적 변수 재설정
+	MAZE_SIZE = size; // 매개 변수 size 로 MAZE_SIZE 정적 변수 재설정
+	maze.resize(size, vector<int>(size, 1)); // 매개 변수 size 로 이차원 벡터 미로 정적 변수의 크기 재설정
+
 	srand(static_cast<unsigned>(time(0))); // 난수 생성기 초기화
 	StartMaze(); // 미로를 그리기 위한 준비 및 미로 생성 함수 호출
 	StartFinishPoint(MAZE_SIZE); // 출발점과 도착점을 생성하는 함수 호출

--- a/Player_move.hpp
+++ b/Player_move.hpp
@@ -6,7 +6,7 @@
 using namespace std;
 
 void DrawClear();
-void Playing();
+void Playing(int size);
 void cursor(int n); // 커서 깜박임 제거
 void StartFinishPoint(int MAZE_SIZE);
 

--- a/a_maze_map.cpp
+++ b/a_maze_map.cpp
@@ -6,8 +6,8 @@
 
 using namespace std;
 
-// 미로의 크기 (홀수로 설정). 이 N은 헤더파일에 정의되어 있음
-vector<vector<int>> maze(N, vector<int>( N, 1)); //(1은 벽, 0은 길)
+int N = 101; // 미로의 크기 (홀수로 설정)
+vector<vector<int>> maze(N, vector<int>(N, 1)); // (1은 벽, 0은 길)
 
 int dx[] = { 0, 1, 0, -1 }; // 상하좌우 이동을 위한 배열
 int dy[] = { -1, 0, 1, 0 };

--- a/a_maze_map.hpp
+++ b/a_maze_map.hpp
@@ -1,7 +1,5 @@
-#ifndef a_maze_map_hpp
+﻿#ifndef a_maze_map_hpp
 #define a_maze_map_hpp
-
-const int N = 13;
 
 void printMaze(int player_x, int player_y, int end_x, int end_y);
 bool exist(int x, int y);

--- a/main.cpp
+++ b/main.cpp
@@ -232,7 +232,7 @@ int StageMenu() { // 스테이지 선택 메뉴 화면을 담당하는 함수
 			Fmod->createStream(".\\Sounds\\Stg1Lv1.mp3", FMOD_LOOP_NORMAL, 0, &Stg1Lv1);
 			Fmod->playSound(Stg1Lv1, 0, false, &channel1); // 유아용 스테이지 Level 1 BGM 재생
 			system("cls");
-			Playing();
+			Playing(13);
 			Fmod->playSound(StageBGM, 0, false, &channel1); // 게임을 클리어한 후에, 스테이지 선택 메뉴 배경음악 다시 재생
 			break;
 		case 2: // 유아용 스테이지의 Level 2를 선택한 경우
@@ -240,7 +240,7 @@ int StageMenu() { // 스테이지 선택 메뉴 화면을 담당하는 함수
 			Fmod->createStream(".\\Sounds\\Stg1Lv2.ogg", FMOD_LOOP_NORMAL, 0, &Stg1Lv2);
 			Fmod->playSound(Stg1Lv2, 0, false, &channel1); // 유아용 스테이지 Level 2 BGM 재생
 			system("cls");
-			Playing();
+			Playing(15);
 			Fmod->playSound(StageBGM, 0, false, &channel1); // 게임을 클리어한 후에, 스테이지 선택 메뉴 배경음악 다시 재생
 			break;
 		case 3: // 일반 플레이어용 스테이지의 Level 1을 선택한 경우
@@ -248,7 +248,7 @@ int StageMenu() { // 스테이지 선택 메뉴 화면을 담당하는 함수
 			Fmod->createStream(".\\Sounds\\Stg2Lv1.mp3", FMOD_LOOP_NORMAL, 0, &Stg2Lv1);
 			Fmod->playSound(Stg2Lv1, 0, false, &channel1); // 일반 플레이어용 스테이지 Level 1 BGM 재생
 			system("cls");
-			Playing();
+			Playing(17);
 			Fmod->playSound(StageBGM, 0, false, &channel1); // 게임을 클리어한 후에, 스테이지 선택 메뉴 배경음악 다시 재생
 			break;
 		case 4: // 일반 플레이어용 스테이지의 Level 2를 선택한 경우
@@ -256,7 +256,7 @@ int StageMenu() { // 스테이지 선택 메뉴 화면을 담당하는 함수
 			Fmod->createStream(".\\Sounds\\Stg2Lv2.mp3", FMOD_LOOP_NORMAL, 0, &Stg2Lv2);
 			Fmod->playSound(Stg2Lv2, 0, false, &channel1); // 일반 플레이어용 스테이지 Level 2 BGM 재생
 			system("cls");
-			Playing();
+			Playing(19);
 			Fmod->playSound(StageBGM, 0, false, &channel1); // 게임을 클리어한 후에, 스테이지 선택 메뉴 배경음악 다시 재생
 			break;
 		case 5: // 노인분들을 위한 스테이지의 Level 1을 선택한 경우
@@ -264,7 +264,7 @@ int StageMenu() { // 스테이지 선택 메뉴 화면을 담당하는 함수
 			Fmod->createStream(".\\Sounds\\Stg3Lv1.mp3", FMOD_LOOP_NORMAL, 0, &Stg3Lv1);
 			Fmod->playSound(Stg3Lv1, 0, false, &channel1); // 노인분들을 위한 스테이지 Level 1 BGM 재생
 			system("cls");
-			Playing();
+			Playing(15);
 			Fmod->playSound(StageBGM, 0, false, &channel1); // 게임을 클리어한 후에, 스테이지 선택 메뉴 배경음악 다시 재생
 			break;
 		case 6: // 노인분들을 위한 스테이지의 Level 2를 선택한 경우
@@ -272,7 +272,7 @@ int StageMenu() { // 스테이지 선택 메뉴 화면을 담당하는 함수
 			Fmod->createStream(".\\Sounds\\Stg3Lv2.ogg", FMOD_LOOP_NORMAL, 0, &Stg3Lv2);
 			Fmod->playSound(Stg3Lv2, 0, false, &channel1); // 노인분들을 위한 스테이지 Level 2 BGM 재생
 			system("cls");
-			Playing();
+			Playing(17);
 			Fmod->playSound(StageBGM, 0, false, &channel1); // 게임을 클리어한 후에, 스테이지 선택 메뉴 배경음악 다시 재생
 			break;
 		case 0: // 메인 화면으로 돌아가는 메뉴를 선택한 경우


### PR DESCRIPTION
- [x] 정적 변수 `N` 의 `const` 키워드 제거
- [X] `Playing()` 함수의 매개 변수 추가
- [X] 미로 크기와 관련된 정적 변수의 값을 재할당
- [X] 이차원 벡터의 `resize` 함수를 사용하여 미로 크기 조절