### PR TITLE
[기능 추가] 폭탄 관련 함수와 폭탄을 밟을 때 효과음 재생 추가

### DIFF
--- a/Player_move.cpp
+++ b/Player_move.cpp
@@ -73,6 +73,9 @@ public:
 	}
 };
 
+int start_x, start_y; // 시작 위치 변수 저장용
+int end_x, end_y; // 도착점 위치 변수 저장용 
+
 class Player { // 여기서 키보드 입력값을 받고, 이동 함수들을 호출 할 예정. 
 private:
 	int x, y;// 플레이어 좌표
@@ -115,10 +118,10 @@ public:
 
 	int getX() const { return x; } // 외부에서 x값을 가져갈 때. x 값을 건들이지 않도록 const를 사용
 	int getY() const { return y; }
+
+	void restart() { x = start_x; y = start_y; }	//폭탄을 밟았을 때 쓰는 함수 / 플레이어의 위치를 처음 위치로 이동시킴
 };
 
-int start_x, start_y; // 시작 위치 변수 저장용
-int end_x, end_y; // 도착점 위치 변수 저장용 
 
 // 스테이지 난이도 선택 후 본격적으로 게임 실행하는 함수, 미로 크기를 size 매개 변수로 받음.
 void Playing(int size) {
@@ -129,15 +132,23 @@ void Playing(int size) {
 	srand(static_cast<unsigned>(time(0))); // 난수 생성기 초기화
 	StartMaze(); // 미로를 그리기 위한 준비 및 미로 생성 함수 호출
 	StartFinishPoint(MAZE_SIZE); // 출발점과 도착점을 생성하는 함수 호출
+	bombset();					//미로 내에 폭탄을 무작위로 생성
 
 	Player player(start_x, start_y, end_x, end_y); // 플레이어 객체 생성
+
 	
+
 	while (true)			// 입력을 받으면 움직이도록 while 문을 계속 수행
 	{
 		printMaze(player.getX(), player.getY(), end_x, end_y); // 미로를 그리는 함수 호출
 		cursor(0);			// 0 = 깜빡임 제거 / 1 = 깜빡임 생성
 
 		player.handleInput(); // 키보드 입력 받는 함수 호출
+
+		if (maze[player.getX()][player.getY()] == 2) {	//플레이어가 이동한 후 그 위치에 폭탄이 있다면
+			maze[player.getX()][player.getY()] = 0;		//우선 폭탄이 터졌으므르 폭탄을 없애고
+			player.restart();							//플레이어를 시작 위치로 이동시킴
+		}
 
 		Sleep(5);			// 5ms 간격으로 화면 갱신
 		system("cls");		// 화면 갱신
@@ -179,6 +190,37 @@ void StartFinishPoint(int MAZE_SIZE) { // 출발점과 도착점을 생성하는
 	end_x = MAZE_SIZE - 1 - start_x; // 이 수식을 계산하면 출발점의 대각선 반대에 있는 꼭짓점의 좌표가 도착점으로 설정 됨
 	end_y = MAZE_SIZE - 1 - start_y;
 }
+
+
+//폭탄 설치 함수
+void bombset() {	
+	int bombX, bombY;		//폭탄의 좌표값
+	int count = 0;			//폭탄 개수
+
+	//프로그램 실행을 위해 5로 설정했는데, 전역변수를 하나 만들고 난이도 별로 전역변수 값을 다르게 한 다음 5 위치에 변수를 넣으면 될 듯
+	while (count != 5) {
+
+		bombX = rand() % (MAZE_SIZE - 2) + 1;		//무작위 좌표 선택, 난수 생성기 초기화는 Playing함수에서 이미 함
+		bombY = rand() % (MAZE_SIZE - 2) + 1;
+
+		//폭탄이 미로 밖에 생성될 경우 이를 미로에 반영하지 않고 재생성
+		if (bombX < 0 || bombX >= MAZE_SIZE || bombY < 0 || bombY >= MAZE_SIZE) {
+			continue;
+		}
+
+		//폭탄이 시작지점이나 목적지, 혹은 벽에 생길 경우 역시 재생성
+		if (maze[bombX][bombY] == 1 || bombX == start_x && bombY == start_y || bombX == end_x && bombY == end_y) {
+			continue;
+		}
+
+		//벡터 내에서는 폭탄을 2로 표시
+		maze[bombX][bombY] = 2;
+
+		//폭탄이 올바르게 생성되면 값이 1 증가, continue문으로 스킵하기 때문에 설정한 개수에 달할 때 까지 계속 생성
+		count += 1;
+	}
+};
+
 
 void cursor(int n) { // 커서 깜빡임 제거 용도
 	HANDLE hConsole;

--- a/Player_move.cpp
+++ b/Player_move.cpp
@@ -3,9 +3,14 @@
 #include <conio.h> // _getch 함수를 사용하기 위함
 #include <vector>
 #include "Text.hpp"
+#include "fmod.hpp"
 #include "Player_move.hpp"
 #include "a_maze_map.hpp"
 using namespace std;
+
+extern FMOD::System* Fmod; // Fmod 시스템 클래스를 가리키는 Fmod 포인터를 외부 참조
+extern FMOD::Sound* Die; // 플레이어 사망 효과음 재생 포인터를 외부 참조
+extern FMOD::Channel* channel2; // 채널 2에서 효과음을 재생하도록 외부 참조
 
 extern int N; // a_maze_map.cpp 에서 참조한 미로 크기 
 extern vector<vector<int>> maze; // a_maze_map.cpp 에서 참조한 이차원 벡터 미로
@@ -15,7 +20,7 @@ class Move { // 이동 함수를 담당하는 기본 클래스
 public:
 	virtual bool isMoveBlocked(int x, int y) {
 
-		if (x < 0 || x >= MAZE_SIZE || y < 0 || y >= MAZE_SIZE) { // 이동할려는 방향이 미로의 크기에 벗어나지 않는지 확인
+		if (x < 0 || x >= MAZE_SIZE || y < 0 || y >= MAZE_SIZE) { // 이동하려는 방향이 미로의 크기에 벗어나지 않는지 확인
 			return true; // 벽에 막혔을 때 경고음 소리로 잘못된 키보드 입력이란걸 알림
 		}
 
@@ -78,7 +83,7 @@ int end_x, end_y; // 도착점 위치 변수 저장용
 
 class Player { // 여기서 키보드 입력값을 받고, 이동 함수들을 호출 할 예정. 
 private:
-	int x, y;// 플레이어 좌표
+	int x, y; // 플레이어 좌표
 	int e_x, e_y; // 도착점 좌표 저장용
 	Move* currentMove; // 부모 클래스의 포인터로 자식 클래스의 객체를 동적 할당 함. 다형성을 드러냄
 
@@ -122,7 +127,6 @@ public:
 	void restart() { x = start_x; y = start_y; }	//폭탄을 밟았을 때 쓰는 함수 / 플레이어의 위치를 처음 위치로 이동시킴
 };
 
-
 // 스테이지 난이도 선택 후 본격적으로 게임 실행하는 함수, 미로 크기를 size 매개 변수로 받음.
 void Playing(int size) {
 	N = size; // 매개 변수 size 로 미로 크기 정적 변수 재설정
@@ -132,22 +136,25 @@ void Playing(int size) {
 	srand(static_cast<unsigned>(time(0))); // 난수 생성기 초기화
 	StartMaze(); // 미로를 그리기 위한 준비 및 미로 생성 함수 호출
 	StartFinishPoint(MAZE_SIZE); // 출발점과 도착점을 생성하는 함수 호출
-	bombset();					//미로 내에 폭탄을 무작위로 생성
+	bombset();					 // 미로 내에 폭탄을 무작위로 생성
+	Fmod->createSound(".\\Sounds\\Die.mp3", FMOD_LOOP_OFF, 0, &Die); // 플레이어 사망 효과음 객체 생성
+	Fmod->update();
 
 	Player player(start_x, start_y, end_x, end_y); // 플레이어 객체 생성
 
-	
-
 	while (true)			// 입력을 받으면 움직이도록 while 문을 계속 수행
 	{
+		Fmod->update();
 		printMaze(player.getX(), player.getY(), end_x, end_y); // 미로를 그리는 함수 호출
 		cursor(0);			// 0 = 깜빡임 제거 / 1 = 깜빡임 생성
 
 		player.handleInput(); // 키보드 입력 받는 함수 호출
 
-		if (maze[player.getX()][player.getY()] == 2) {	//플레이어가 이동한 후 그 위치에 폭탄이 있다면
-			maze[player.getX()][player.getY()] = 0;		//우선 폭탄이 터졌으므르 폭탄을 없애고
-			player.restart();							//플레이어를 시작 위치로 이동시킴
+		if (maze[player.getX()][player.getY()] == 2) {	// 플레이어가 이동한 후 그 위치에 폭탄이 있다면
+			Fmod->playSound(Die, 0, false, &channel2);  // 폭탄을 밟으면 플레이어 사망 효과음 재생
+			Fmod->update();
+			maze[player.getX()][player.getY()] = 0;		// 우선 폭탄이 터졌으므르 폭탄을 없애고
+			player.restart();							// 플레이어를 시작 위치로 이동시킴
 		}
 
 		Sleep(5);			// 5ms 간격으로 화면 갱신
@@ -191,36 +198,34 @@ void StartFinishPoint(int MAZE_SIZE) { // 출발점과 도착점을 생성하는
 	end_y = MAZE_SIZE - 1 - start_y;
 }
 
-
 //폭탄 설치 함수
 void bombset() {	
-	int bombX, bombY;		//폭탄의 좌표값
-	int count = 0;			//폭탄 개수
+	int bombX, bombY;		// 폭탄의 좌표값
+	int count = 0;			// 폭탄 개수
 
-	//프로그램 실행을 위해 5로 설정했는데, 전역변수를 하나 만들고 난이도 별로 전역변수 값을 다르게 한 다음 5 위치에 변수를 넣으면 될 듯
+	// 프로그램 실행을 위해 5로 설정했는데, 전역변수를 하나 만들고 난이도 별로 전역변수 값을 다르게 한 다음 5 위치에 변수를 넣으면 될 듯
 	while (count != 5) {
 
 		bombX = rand() % (MAZE_SIZE - 2) + 1;		//무작위 좌표 선택, 난수 생성기 초기화는 Playing함수에서 이미 함
 		bombY = rand() % (MAZE_SIZE - 2) + 1;
 
-		//폭탄이 미로 밖에 생성될 경우 이를 미로에 반영하지 않고 재생성
+		// 폭탄이 미로 밖에 생성될 경우 이를 미로에 반영하지 않고 재생성
 		if (bombX < 0 || bombX >= MAZE_SIZE || bombY < 0 || bombY >= MAZE_SIZE) {
 			continue;
 		}
 
-		//폭탄이 시작지점이나 목적지, 혹은 벽에 생길 경우 역시 재생성
+		// 폭탄이 시작지점이나 목적지, 혹은 벽에 생길 경우 역시 재생성
 		if (maze[bombX][bombY] == 1 || bombX == start_x && bombY == start_y || bombX == end_x && bombY == end_y) {
 			continue;
 		}
 
-		//벡터 내에서는 폭탄을 2로 표시
+		// 벡터 내에서는 폭탄을 2로 표시
 		maze[bombX][bombY] = 2;
 
-		//폭탄이 올바르게 생성되면 값이 1 증가, continue문으로 스킵하기 때문에 설정한 개수에 달할 때 까지 계속 생성
+		// 폭탄이 올바르게 생성되면 값이 1 증가, continue문으로 스킵하기 때문에 설정한 개수에 달할 때 까지 계속 생성
 		count += 1;
 	}
 };
-
 
 void cursor(int n) { // 커서 깜빡임 제거 용도
 	HANDLE hConsole;

--- a/Player_move.hpp
+++ b/Player_move.hpp
@@ -2,6 +2,7 @@
 #define Player_move_hpp
 
 #include <iostream>	
+#include <algorithm>
 #pragma warning(disable : 4996) // kbhit 오류 무시
 using namespace std;
 
@@ -9,5 +10,6 @@ void DrawClear();
 void Playing(int size);
 void cursor(int n); // 커서 깜박임 제거
 void StartFinishPoint(int MAZE_SIZE);
+void bombset();
 
 #endif

--- a/a_maze_map.cpp
+++ b/a_maze_map.cpp
@@ -21,7 +21,7 @@ void printMaze(int player_x, int player_y, int end_x, int end_y) {
             else if (j == end_x && i == end_y) {
                 cout << "◈"; // 도착점 아이콘
             }
-            else if (maze[j][i] == 0) {
+            else if (maze[j][i] == 0 || maze[j][i] == 2) {  //폭탄을 보이지 않게 해 난이도를 상승시킴
                 cout << "  "; // 길
             }
             else {

--- a/a_maze_map.cpp
+++ b/a_maze_map.cpp
@@ -21,7 +21,7 @@ void printMaze(int player_x, int player_y, int end_x, int end_y) {
             else if (j == end_x && i == end_y) {
                 cout << "◈"; // 도착점 아이콘
             }
-            else if (maze[j][i] == 0 || maze[j][i] == 2) {  //폭탄을 보이지 않게 해 난이도를 상승시킴
+            else if (maze[j][i] == 0 || maze[j][i] == 2) { // 폭탄을 보이지 않게 해 난이도를 상승시킴
                 cout << "  "; // 길
             }
             else {


### PR DESCRIPTION
폭탄은 벡터상에서 2로 표시, 미로 출력시 0과 2(길과 폭탄)은 동일하게 표시되며, 폭탄 위치에 도달할 경우 처음 위치로 돌아가며 해당 폭탄은 제거되어 길로 바뀜.

현재 난이도에 따른 적절한 폭탄의 개수를 몰라 설정하지 않았는데, 난이도 별로 적절한 폭탄 개수를 알게 된다면 전역 변수를 만들고 난이도 마다 전역 변수 값을 다르게 하면 될 것으로 보임.