### PR TITLE
[기능 수정] 폭탄의 표시와 폭발 판정 생성, 아이콘 가독성 향상

### DIFF
--- a/Player_move.cpp
+++ b/Player_move.cpp
@@ -15,6 +15,7 @@ extern FMOD::Channel* channel2; // 채널 2에서 효과음을 재생하도록 �
 extern int N; // a_maze_map.cpp 에서 참조한 미로 크기 
 extern vector<vector<int>> maze; // a_maze_map.cpp 에서 참조한 이차원 벡터 미로
 int MAZE_SIZE = N; // 미로 크기
+extern int BombCount;// main.cpp 에서 참조한 폭탄 개수
 
 class Move { // 이동 함수를 담당하는 기본 클래스
 public:
@@ -127,6 +128,7 @@ public:
 	void restart() { x = start_x; y = start_y; }	//폭탄을 밟았을 때 쓰는 함수 / 플레이어의 위치를 처음 위치로 이동시킴
 };
 
+int turnCount = 0; //이동 횟수를 저장하는 변수
 // 스테이지 난이도 선택 후 본격적으로 게임 실행하는 함수, 미로 크기를 size 매개 변수로 받음.
 void Playing(int size) {
 	N = size; // 매개 변수 size 로 미로 크기 정적 변수 재설정
@@ -150,8 +152,9 @@ void Playing(int size) {
 		cursor(0);			// 0 = 깜빡임 제거 / 1 = 깜빡임 생성
 
 		player.handleInput(); // 키보드 입력 받는 함수 호출
+		turnCount++;		  // 키보드 입력시 숫자 증가
 
-		if (maze[player.getX()][player.getY()] == 2) {	// 플레이어가 이동한 후 그 위치에 폭탄이 있다면
+		if (maze[player.getX()][player.getY()] == 2 && turnCount % 2 == 0) {	// 플레이어가 짝수 번 이동한 후 그 위치에 폭탄이 있다면
 			Fmod->playSound(Die, 0, false, &channel2);  // 폭탄을 밟으면 플레이어 사망 효과음 재생
 			Fmod->update();
 			maze[player.getX()][player.getY()] = 0;		// 우선 폭탄이 터졌으므르 폭탄을 없애고
@@ -204,8 +207,8 @@ void bombset() {
 	int bombX, bombY;		// 폭탄의 좌표값
 	int count = 0;			// 폭탄 개수
 
-	// 프로그램 실행을 위해 5로 설정했는데, 전역변수를 하나 만들고 난이도 별로 전역변수 값을 다르게 한 다음 5 위치에 변수를 넣으면 될 듯
-	while (count != 5) {
+	// 난이도 별로 폭탄 생성
+	while (count != BombCount) {
 
 		bombX = rand() % (MAZE_SIZE - 2) + 1;		//무작위 좌표 선택, 난수 생성기 초기화는 Playing함수에서 이미 함
 		bombY = rand() % (MAZE_SIZE - 2) + 1;

--- a/a_maze_map.cpp
+++ b/a_maze_map.cpp
@@ -1,4 +1,5 @@
 ﻿#include "a_maze_map.hpp"
+#include "Text.hpp"
 #include <iostream>
 #include <vector>
 #include <cstdlib>
@@ -17,16 +18,22 @@ void printMaze(int player_x, int player_y, int end_x, int end_y) {
     for (int i = 0; i < N; i++) {
         for (int j = 0; j < N; j++) {
             if (j == player_x && i == player_y) {
+                TextColor(DEEP_YELLOW);
                 cout << "★"; // 플레이어 아이콘
+                TextColor(DEEP_WHITE);
             }
             else if (j == end_x && i == end_y) {
+                TextColor(DEEP_GREEN);
                 cout << "◈"; // 도착점 아이콘
+                TextColor(DEEP_WHITE);
             }
             else if (maze[j][i] == 0 || (maze[j][i] == 2 && turnCount % 2 == 1)) { // 폭탄을 보이지 않게 해 난이도를 상승시킴
                 cout << "  "; // 길
             }
             else if (maze[j][i] == 2 && turnCount % 2 == 0) { // 짝수 번 움직였을 때에는 폭탄을 표시
+                TextColor(DEEP_OC);
                 cout << "♠"; // 폭탄
+                TextColor(DEEP_WHITE);
             }
             else {
                 cout << "■"; // 벽

--- a/a_maze_map.cpp
+++ b/a_maze_map.cpp
@@ -8,6 +8,7 @@ using namespace std;
 
 int N = 101; // 미로의 크기 (홀수로 설정)
 vector<vector<int>> maze(N, vector<int>(N, 1)); // (1은 벽, 0은 길)
+extern int turnCount;
 
 int dx[] = { 0, 1, 0, -1 }; // 상하좌우 이동을 위한 배열
 int dy[] = { -1, 0, 1, 0 };
@@ -21,8 +22,11 @@ void printMaze(int player_x, int player_y, int end_x, int end_y) {
             else if (j == end_x && i == end_y) {
                 cout << "◈"; // 도착점 아이콘
             }
-            else if (maze[j][i] == 0 || maze[j][i] == 2) { // 폭탄을 보이지 않게 해 난이도를 상승시킴
+            else if (maze[j][i] == 0 || (maze[j][i] == 2 && turnCount % 2 == 1)) { // 폭탄을 보이지 않게 해 난이도를 상승시킴
                 cout << "  "; // 길
+            }
+            else if (maze[j][i] == 2 && turnCount % 2 == 0) { // 짝수 번 움직였을 때에는 폭탄을 표시
+                cout << "♠"; // 폭탄
             }
             else {
                 cout << "■"; // 벽

--- a/main.cpp
+++ b/main.cpp
@@ -175,13 +175,21 @@ void DrawGameInfo() // 게임 정보 화면을 출력하는 함수
 	gotoxy(10, 18, "- Level 1");
 	gotoxy(10, 19, "- Level 2");
 
-	TextColor(DEEP_OC); //조작키 설명 입력
-	gotoxy(52, 10, "▦ 조작키 설명");
+	TextColor(DEEP_OC); // 아이콘 설명 입력
+	gotoxy(40, 10, "▦ 아이콘 설명");
 	TextColor(DEEP_WHITE);
-	gotoxy(54, 12, "▦ w : 위");
-	gotoxy(54, 13, "▦ s : 아래");
-	gotoxy(54, 14, "▦ a : 왼쪽");
-	gotoxy(54, 15, "▦ d : 오른쪽");
+	gotoxy(42, 12, "★ : 플레이어");
+	gotoxy(42, 13, "◈ : 도착 지점");
+	gotoxy(42, 14, "♠ : 폭탄(밟으면 원위치로)");
+	gotoxy(42, 15, "■ : 벽");
+
+	TextColor(DEEP_OC); // 조작키 설명 입력
+	gotoxy(71, 10, "▦ 조작키 설명");
+	TextColor(DEEP_WHITE);
+	gotoxy(73, 12, "▦ w : 위");
+	gotoxy(73, 13, "▦ s : 아래");
+	gotoxy(73, 14, "▦ a : 왼쪽");
+	gotoxy(73, 15, "▦ d : 오른쪽");
 
 	gotoxy(6, 22, "※ 아무키나 누르면 메인 화면으로 돌아갑니다...", DEEP_WHITE);
 	system("pause>null"); // 게임 정보 화면을 출력하고 아무 키를 입력받을 때까지 일시정지, 아무 키나 누르면 다시 메인 화면으로 돌아감.

--- a/main.cpp
+++ b/main.cpp
@@ -230,6 +230,7 @@ int DrawStageMenu() { // 플레이어 연령 별 스테이지를 선택하는 �
 	return menu; // 입력받은 스테이지 메뉴 번호를 반환. (StageMenu 함수의 switch 문에서 이의 반환값이 사용됨.)
 }
 
+int BombCount;	  // 폭탄 개수 저장 변수
 int StageMenu() { // 스테이지 선택 메뉴 화면을 담당하는 함수
 	Fmod->createStream(".\\Sounds\\Menu_SelectStage.ogg", FMOD_LOOP_NORMAL, 0, &StageBGM); // 스테이지 선택 메뉴 배경음악 사운드 객체 생성.
 	Fmod->playSound(StageBGM, 0, false, &channel1); // 스테이지 선택 메뉴 배경음악 재생
@@ -244,6 +245,7 @@ int StageMenu() { // 스테이지 선택 메뉴 화면을 담당하는 함수
 			Fmod->createStream(".\\Sounds\\Stg1Lv1.mp3", FMOD_LOOP_NORMAL, 0, &Stg1Lv1);
 			Fmod->playSound(Stg1Lv1, 0, false, &channel1); // 유아용 스테이지 Level 1 BGM 재생
 			system("cls");
+			BombCount = 0;
 			Playing(13);
 			Fmod->playSound(StageBGM, 0, false, &channel1); // 게임을 클리어한 후에, 스테이지 선택 메뉴 배경음악 다시 재생
 			break;
@@ -252,6 +254,7 @@ int StageMenu() { // 스테이지 선택 메뉴 화면을 담당하는 함수
 			Fmod->createStream(".\\Sounds\\Stg1Lv2.ogg", FMOD_LOOP_NORMAL, 0, &Stg1Lv2);
 			Fmod->playSound(Stg1Lv2, 0, false, &channel1); // 유아용 스테이지 Level 2 BGM 재생
 			system("cls");
+			BombCount = 2;
 			Playing(15);
 			Fmod->playSound(StageBGM, 0, false, &channel1); // 게임을 클리어한 후에, 스테이지 선택 메뉴 배경음악 다시 재생
 			break;
@@ -260,6 +263,7 @@ int StageMenu() { // 스테이지 선택 메뉴 화면을 담당하는 함수
 			Fmod->createStream(".\\Sounds\\Stg2Lv1.mp3", FMOD_LOOP_NORMAL, 0, &Stg2Lv1);
 			Fmod->playSound(Stg2Lv1, 0, false, &channel1); // 일반 플레이어용 스테이지 Level 1 BGM 재생
 			system("cls");
+			BombCount = 4;
 			Playing(17);
 			Fmod->playSound(StageBGM, 0, false, &channel1); // 게임을 클리어한 후에, 스테이지 선택 메뉴 배경음악 다시 재생
 			break;
@@ -268,6 +272,7 @@ int StageMenu() { // 스테이지 선택 메뉴 화면을 담당하는 함수
 			Fmod->createStream(".\\Sounds\\Stg2Lv2.mp3", FMOD_LOOP_NORMAL, 0, &Stg2Lv2);
 			Fmod->playSound(Stg2Lv2, 0, false, &channel1); // 일반 플레이어용 스테이지 Level 2 BGM 재생
 			system("cls");
+			BombCount = 7;
 			Playing(19);
 			Fmod->playSound(StageBGM, 0, false, &channel1); // 게임을 클리어한 후에, 스테이지 선택 메뉴 배경음악 다시 재생
 			break;
@@ -288,6 +293,7 @@ int StageMenu() { // 스테이지 선택 메뉴 화면을 담당하는 함수
 			system("cls");
 			system("mode con:cols=50 lines=18");
 			fontSize(38); // 글꼴 크기를 크게 조절(유니버셜 디자인)
+			BombCount = 1;
 			Playing(17);
 			Fmod->playSound(StageBGM, 0, false, &channel1); // 게임을 클리어한 후에, 스테이지 선택 메뉴 배경음악 다시 재생
 			break;


### PR DESCRIPTION
기존 방식을 사용할 시 적이 생성돼 플레이어를 추적하는 상황에서 폭탄을 밟을 경우 사실상 게임이 종료됨.
따라서, 기존 기능을 이하의 방식으로 변경함.

- [X] 플레이어가 이동한 횟수(키보드를 입력한 횟수)를 세고, 해당 횟수가 짝수일 경우에만 폭발함.
- [X] 위 기능에 맞춰 짝수 번 이동한 상황에서만 폭탄이 표시됨.
- [X] 위 기능들과는 별개로, 난이도 별로 폭탄이 생성되는 개수를 조절함.